### PR TITLE
Add Dependabot configuration and workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "main"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,31 @@
+name: Run Dependabot updates
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run Dependabot
+        uses: dependabot/dependabot-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          directory: "/"
+          package-ecosystem: "pip"
+
+      - name: Run Dependabot for GitHub Actions
+        uses: dependabot/dependabot-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          directory: "/"
+          package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- configure Dependabot to monitor pip and GitHub Actions dependencies weekly
- add workflow to run Dependabot action on a weekly schedule and on demand

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcfd8c994c832890e42f321baf7465